### PR TITLE
Add requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,8 @@ setup(
         'numpy',
         'setuptools',
         'pip',
+        'termcolor',
+        'colorama',
     ],
     url='https://github.com/BUNPC/pysnirf2',
     packages=find_packages(exclude=('tests', 'gen')),


### PR DESCRIPTION
I tried to use pysnirf2 at https://github.com/mne-tools/mne-nirs/pull/421 but it errors complaining that it doesn't have termcolor installed. This is the error

```bash
/opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
mne_nirs/io/snirf/tests/test_snirf.py:10: in <module>
    from pysnirf2 import validateSnirf
/opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/pysnirf2/__init__.py:1: in <module>
    from .pysnirf2 import *
/opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/pysnirf2/pysnirf2.py:10: in <module>
    import termcolor
E   ModuleNotFoundError: No module named 'termcolor'
```

I often get confused about python packaging, so I am not sure if this PR will actually fix the problem. Or should I just add the two packages to my own install script? I had hoped that all I needed to run was `pip install pysnirf2`