### PR TITLE
MAINT: Numpy 2.0 compat

### DIFF
--- a/snirf/pysnirf2.py
+++ b/snirf/pysnirf2.py
@@ -144,7 +144,7 @@ _DTYPE_VAR_LEN_STR = 'O'  # Variable length string
 
 _INT_DTYPES = [int, np.int32, np.int64]
 _FLOAT_DTYPES = [float, np.float64]
-_STR_DTYPES = [str, np.string_]
+_STR_DTYPES = [str, np.bytes_]
 
 # -- Dataset creators  ---------------------------------------
 


### PR DESCRIPTION
Should fix https://dev.azure.com/mne-tools/mne-python/_build/results?buildId=26981&view=logs&jobId=dded70eb-633c-5c42-e995-a7f8d1f99d91&j=dded70eb-633c-5c42-e995-a7f8d1f99d91&t=d18f7f2f-13af-5901-1cbc-7fa039d0db3a
```
================================== FAILURES ===================================
________________________________ test_birthday ________________________________
mne\io\snirf\tests\test_snirf.py:475: in test_birthday
    snirf = pytest.importorskip("snirf")
C:\hostedtoolcache\windows\Python\3.11.5\x64\Lib\site-packages\snirf\__init__.py:1: in <module>
    from .pysnirf2 import *
C:\hostedtoolcache\windows\Python\3.11.5\x64\Lib\site-packages\snirf\pysnirf2.py:145: in <module>
    _STR_DTYPES = [str, np.string_]
C:\hostedtoolcache\windows\Python\3.11.5\x64\Lib\site-packages\numpy\__init__.py:397: in __getattr__
    raise AttributeError(
E   AttributeError: `np.string_` was removed in the NumPy 2.0 release. Use `np.bytes_` instead.
```