### PR TITLE
Bump version to v0.8.0

### DIFF
--- a/snirf/__version__.py
+++ b/snirf/__version__.py
@@ -1,2 +1,2 @@
-__VERSION__ = (0, 7, 4)
+__VERSION__ = (0, 8, 0)
 __version__ = '.'.join(map(str, __VERSION__))


### PR DESCRIPTION
I am not entirely sure of the release procedure here. But from looking at the code, I think if we bump the version number, then make a new tag, it should cut a new pypi release.

Wasn't sure if this should be a minor or major change, so I went with the safer option and went the larger one.