### PR TITLE
Validation of conflicting measurment lists

### DIFF
--- a/snirf/pysnirf2.py
+++ b/snirf/pysnirf2.py
@@ -576,6 +576,9 @@ _CODES = {
     (27, 1, 'The optional indexed group has no elements'),
     # OK (Severity 0)
     'OK': (28, 0, 'No issues detected'),
+    'CONFLICTING_FIELDS_PRESENT': (
+        29, 3, 'Multiple conflicting fields are present in the same file'
+    )
 }
 
 
@@ -6764,19 +6767,19 @@ class DataElement(DataElement):
         # Override measurementList/measurementLists validation, only one is required
         ml = self.measurementList is not None
         mls = self.measurementLists is not None
-        if (ml and mls):
+        if (ml or mls):
             result._add(self.location + '/measurementList', 'OK')
             result._add(self.location + '/measurementLists', 'OK')
-        elif (ml or mls):
+        elif (ml and mls):
             result._add(self.location + '/measurementList',
-                        ['OPTIONAL_DATASET_MISSING', 'OK'][int(ml)])
+                        'CONFLICTING_FIELDS_PRESENT')
             result._add(self.location + '/measurementLists',
-                        ['OPTIONAL_DATASET_MISSING', 'OK'][int(mls)])
+                        'CONFLICTING_FIELDS_PRESENT')
         else:
             result._add(self.location + '/measurementList',
-                        ['REQUIRED_DATASET_MISSING', 'OK'][int(ml)])
+                        'REQUIRED_DATASET_MISSING')
             result._add(self.location + '/measurementLists',
-                        ['REQUIRED_DATASET_MISSING', 'OK'][int(mls)])
+                        'REQUIRED_DATASET_MISSING')
 
         # Check time/dataTimeSeries length agreement
         if all(attr is not None for attr in [self.time, self.dataTimeSeries]):

--- a/tests/test.py
+++ b/tests/test.py
@@ -817,6 +817,9 @@ class PySnirf2_Test(unittest.TestCase):
 
         assert sizes[1] < sizes[0], 'Dynamically-loaded files not smaller in memory'
 
+    def test_conflicting_fields(self):
+        # TODO
+        pass
 
     def setUp(self):
         if VERBOSE:


### PR DESCRIPTION
- Add validation for the new conditional symbol introduced in https://github.com/fNIRS/snirf/pull/166
- Fixes some `REQUIRED_DATASET_MISSING` validation issues

**TODOs**:
- [ ] Add a test snirf file with both `measurementList` and `measurementLists`
- [ ] Write a test for the new `CONFLICTING_FIELDS_PRESENT` error

*Ping @sreekanthkura7*

@sstucker, we were wondering if introducing a new error code (after the `OK` code) will be okay with the rest of the validation?